### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,10 @@ MAINTAINER Charles Gunzelman
 
 # Download nxfilter
 RUN wget -q http://nxfilter.org/download/nxfilter-3.1.7.zip
-RUN mkdir /nxfilter
-RUN unzip nxfil* -d /nxfilter
-RUN rm -f *.zip
-RUN chmod +x /nxfilter/bin/startup.sh
+
+RUN mkdir /nxfilter \
+  && unzip nxfil* -d /nxfilter \
+  && rm -f *.zip \
+  && chmod +x /nxfilter/bin/startup.sh
+  
 CMD /nxfilter/bin/startup.sh


### PR DESCRIPTION
Using less `RUN` will end in a smaller image because less layers are used and packed in the final build.

wget is let alone for cache reasons. 
