### PR TITLE
fix issue with config directory failing with bind mounts

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,14 @@
+name: Docker Image CI
+
+on: [push]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -s -L http://www.nxfilter.org/|grep Download \
   |grep filter-.*zip|grep -v mediafire \
   |xargs -n1 wget -q && mkdir -p /nxfilter \
   && unzip -o nxfil* -d /nxfilter \
-  && cp /nxfilter/config /nxfilter/config-bak \
+  && cp /nxfilter/conf /nxfilter/conf-bak \
   && chmod +x /nxfilter/bin/startup.sh \
   && rm -f *.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -s -L http://www.nxfilter.org/|grep Download \
   |grep filter-.*zip|grep -v mediafire \
   |xargs -n1 wget -q && mkdir -p /nxfilter \
   && unzip -o nxfil* -d /nxfilter \
-  && cp -R /nxfilter/conf /nxfilter/conf-bak \
+  && cp -R /nxfilter/conf /nxfilter/conf-default \
   && chmod +x /nxfilter/bin/startup.sh \
   && rm -f *.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Charles Gunzelman "cgunzelman@gmail.com"
 LABEL org.label-schema.docker.dockerfile="/Dockerfile" \
       org.label-schema.vcs-type="Git" \
       org.label-schema.vcs-url="https://github.com/packetworks/docker-nxfilter"
-      
+
 # Download nxfilter
 RUN curl -s -L http://www.nxfilter.org/|grep Download \
   |grep -Eo "(http|https)://[a-zA-Z0-9./?=_-]*" \
@@ -12,8 +12,8 @@ RUN curl -s -L http://www.nxfilter.org/|grep Download \
   |xargs -n1 curl -s -L \
   |grep -Eo "(http|https)://[a-zA-Z0-9./?=_-]*" \
   |grep filter-.*zip|grep -v mediafire \
-  |xargs -n1 wget -q && mkdir /nxfilter \
-  && unzip nxfil* -d /nxfilter \
+  |xargs -n1 wget -q && mkdir -p /nxfilter \
+  && unzip -o nxfil* -d /nxfilter \
   && chmod +x /nxfilter/bin/startup.sh \
   && rm -f *.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,7 @@ VOLUME /nxfilter/config
 VOLUME /nxfilter/db
 VOLUME /nxfilter/log
 
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
 CMD ["/nxfilter/bin/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,13 @@ RUN curl -s -L http://www.nxfilter.org/|grep Download \
   |grep filter-.*zip|grep -v mediafire \
   |xargs -n1 wget -q && mkdir -p /nxfilter \
   && unzip -o nxfil* -d /nxfilter \
+  && cp /nxfilter/config /nxfilter/config-bak
   && chmod +x /nxfilter/bin/startup.sh \
   && rm -f *.zip
 
 COPY --from=vimagick/sslsplit / /
+VOLUME /nxfilter/config
+VOLUME /nxfilter/db
+VOLUME /nxfilter/log
 
-#CMD ["/nxfilter/bin/startup.sh","start"]
 CMD ["/nxfilter/bin/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -s -L http://www.nxfilter.org/|grep Download \
   |grep filter-.*zip|grep -v mediafire \
   |xargs -n1 wget -q && mkdir -p /nxfilter \
   && unzip -o nxfil* -d /nxfilter \
-  && cp /nxfilter/conf /nxfilter/conf-bak \
+  && cp -R /nxfilter/conf /nxfilter/conf-bak \
   && chmod +x /nxfilter/bin/startup.sh \
   && rm -f *.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -s -L http://www.nxfilter.org/|grep Download \
   |grep filter-.*zip|grep -v mediafire \
   |xargs -n1 wget -q && mkdir -p /nxfilter \
   && unzip -o nxfil* -d /nxfilter \
-  && cp /nxfilter/config /nxfilter/config-bak
+  && cp /nxfilter/config /nxfilter/config-bak \
   && chmod +x /nxfilter/bin/startup.sh \
   && rm -f *.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,6 @@ RUN curl -s -L http://www.nxfilter.org/|grep Download \
   && rm -f *.zip
 
 COPY --from=vimagick/sslsplit / /
-VOLUME /nxfilter/config
-VOLUME /nxfilter/db
-VOLUME /nxfilter/log
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 if [ ! -f "/nxfilter/conf/cfg.default" ]; then
-  cp -a /nxfilter/conf-bak/. /nxfilter/conf/
+  cp -a /nxfilter/conf-default/. /nxfilter/conf/
 fi
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ ! -f "/nxfilter/conf/cfg.default" ]; then
+  cp -a /nxfilter/conf-bak/. /nxfilter/conf/
+fi
+exec "$@"


### PR DESCRIPTION
This will resolve a problem that prevents bind mounts from being used with this container.

The following error occurred when using bind mounts
```
"Exception in thread "main" java.lang.NullPointerException
at nxd.Main.<init>(Unknown Source)
at nxd.Main.main(Unknown Source)
Exception in thread "Thread-0" java.lang.NullPointerException
at nxd.o.run(Unknown Source)"
```

this is because of the `/nxfilter/config` directory which was already populated is overwritten when you `/nxfilter/config` is mounted

To resolve this the dockerfile will copy `/nxfilter/config` to `/nxfilter/conf-default` and `entrypoint.sh` will then copy it back if the config files are missing.